### PR TITLE
use selenium instead of talking directly to phantom

### DIFF
--- a/phantomjs-example/readme.md
+++ b/phantomjs-example/readme.md
@@ -2,6 +2,7 @@ phantomjs-example
 =============
 
 * Install PhantomJS
+* Ensure that the directory containing the phantomjs executable is in your PATH
 * Run `npm install`
-* Make sure you have PhantomJS WebDriver running with `phantomjs --webdriver=4444`
+* Start your local Selenium server
 * Run tests: `npm test`

--- a/phantomjs-example/tests/intern.js
+++ b/phantomjs-example/tests/intern.js
@@ -1,12 +1,10 @@
 define({
  environments: [
-    { browserName: 'phantom' }
+    { browserName: 'phantomjs' }
   ],
 
   suites: [ 'tests/test_example.js' ],
-  tunnelOptions: {
-    port: 4445
-  },
+  tunnel: 'NullTunnel',
 
   excludeInstrumentation: /./
 });


### PR DESCRIPTION
Thanks to @jason0x43 for pointing out the bug that prevents Intern 2 from talking to PhantomJS directly.

Brings `intern.js` in line w/ [wiki page](https://github.com/theintern/intern/wiki/Using-Intern-with-PhantomJS) and instructs user to start Selenium instead of PhantomJS.

This got it working in my environment.

Resolves #6
