### PR TITLE
Fix Bower component destination directory.

### DIFF
--- a/dojo-example/.bowerrc
+++ b/dojo-example/.bowerrc
@@ -1,0 +1,4 @@
+{
+  "directory" : "js/lib"
+}
+


### PR DESCRIPTION
Fix for issue https://github.com/theintern/intern-examples/issues/10 - bower installes components in the wrong directory. 

Signed-off-by: Bogdan Bivolaru osbiv@yahoo.com
