### PR TITLE
Bump to Intern 3.0.0

### DIFF
--- a/phantomjs-example/package.json
+++ b/phantomjs-example/package.json
@@ -5,6 +5,6 @@
     "test": "intern-runner config=tests/intern"
   },
   "devDependencies": {
-    "intern": "~2.2.2"
+    "intern": "~3.0.0"
   }
 }


### PR DESCRIPTION
Demonstrates that this new version hangs when executed against PhantomJS/Selenium.

The output I see is:

```
> phantomjs-example@0.1.0 test /Users/ben/code/intern-examples/phantomjs-example
> intern-runner config=tests/intern

Listening on 0.0.0.0:9000
```

I do not see any log output in Selenium or ChromeDriver logs. AFAICT, Intern is not even attempting a connection.