### PR TITLE
Ignore node_modules code coverage on Windows

### DIFF
--- a/dojo-example/tests/intern.js
+++ b/dojo-example/tests/intern.js
@@ -57,5 +57,5 @@ define({
 	functionalSuites: [ 'tests/functional/Todo' ],
 
 	// A regular expression matching URLs to files that should not be included in code coverage analysis
-	excludeInstrumentation: /^tests|js\/lib\/*|node_modules\//
+	excludeInstrumentation: /^tests|js\/lib\/*|^node_modules/
 });


### PR DESCRIPTION
Paths in Windows don't rely on `/`, so the regex wasn't excluding the `node_modules` from code coverage results.


Before fix:

````
------------------------------------------|-----------|-----------|-----------|-----------|
File                                      |   % Stmts |% Branches |   % Funcs |   % Lines |
------------------------------------------|-----------|-----------|-----------|-----------|
   js\todo\                               |     82.61 |     68.75 |     72.73 |     81.82 |
      CssToggleWidget.js                  |       100 |        70 |       100 |       100 |
      TodoList.js                         |        40 |         0 |     33.33 |        40 |
      app18.js                            |     91.67 |       100 |        75 |     91.67 |
   js\todo\ctrl\                          |     62.96 |     48.15 |     62.96 |     64.15 |
      RouteController.js                  |     91.67 |        75 |        80 |     91.67 |
      TodoListRefController.js            |     21.43 |         0 |        25 |     23.08 |
      TodoRefController.js                |     68.42 |     61.54 |        80 |     68.42 |
      _HashCompletedMixin.js              |     77.78 |        50 |        75 |     77.78 |
   js\todo\form\                          |     83.33 |        50 |     71.43 |     83.33 |
      CheckBox.js                         |       100 |       100 |       100 |       100 |
      InlineEditBox.js                    |     78.95 |        50 |        50 |     78.95 |
   js\todo\misc\                          |     83.33 |       100 |        75 |     83.33 |
      HashSelectedConverter.js            |     66.67 |       100 |        50 |     66.67 |
      LessThanOrEqualToConverter.js       |       100 |       100 |       100 |       100 |
   js\todo\model\                         |     82.76 |        60 |        70 |     85.19 |
      SimpleTodoModel.js                  |     82.76 |        60 |        70 |     85.19 |
   js\todo\store\                         |        72 |        50 |     77.78 |        72 |
      LocalStorage.js                     |        72 |        50 |     77.78 |        72 |
   node_modules\intern\                   |        70 |        50 |       100 |        70 |
      chai.js                             |        70 |        50 |       100 |        70 |
   node_modules\intern\lib\               |     45.68 |     22.22 |     36.84 |     45.68 |
      Test.js                             |     45.68 |     22.22 |     36.84 |     45.68 |
   node_modules\intern\lib\interfaces\    |        72 |      37.5 |       100 |        72 |
      object.js                           |        72 |      37.5 |       100 |        72 |
   node_modules\intern\node_modules\chai\ |     37.97 |      8.25 |     26.14 |      39.4 |
      chai.js                             |     37.97 |      8.25 |     26.14 |      39.4 |
------------------------------------------|-----------|-----------|-----------|-----------|
All files                                 |     43.46 |     15.72 |     36.83 |     44.83 |
------------------------------------------|-----------|-----------|-----------|-----------|
````

After fix:

````
------------------------------------|-----------|-----------|-----------|-----------|
File                                |   % Stmts |% Branches |   % Funcs |   % Lines |
------------------------------------|-----------|-----------|-----------|-----------|
   todo\                            |     82.61 |     68.75 |     72.73 |     81.82 |
      CssToggleWidget.js            |       100 |        70 |       100 |       100 |
      TodoList.js                   |        40 |         0 |     33.33 |        40 |
      app18.js                      |     91.67 |       100 |        75 |     91.67 |
   todo\ctrl\                       |     62.96 |     48.15 |     62.96 |     64.15 |
      RouteController.js            |     91.67 |        75 |        80 |     91.67 |
      TodoListRefController.js      |     21.43 |         0 |        25 |     23.08 |
      TodoRefController.js          |     68.42 |     61.54 |        80 |     68.42 |
      _HashCompletedMixin.js        |     77.78 |        50 |        75 |     77.78 |
   todo\form\                       |     83.33 |        50 |     71.43 |     83.33 |
      CheckBox.js                   |       100 |       100 |       100 |       100 |
      InlineEditBox.js              |     78.95 |        50 |        50 |     78.95 |
   todo\misc\                       |     83.33 |       100 |        75 |     83.33 |
      HashSelectedConverter.js      |     66.67 |       100 |        50 |     66.67 |
      LessThanOrEqualToConverter.js |       100 |       100 |       100 |       100 |
   todo\model\                      |     82.76 |        60 |        70 |     85.19 |
      SimpleTodoModel.js            |     82.76 |        60 |        70 |     85.19 |
   todo\store\                      |        72 |        50 |     77.78 |        72 |
      LocalStorage.js               |        72 |        50 |     77.78 |        72 |
------------------------------------|-----------|-----------|-----------|-----------|
All files                           |     74.53 |     56.32 |     69.12 |     75.16 |
------------------------------------|-----------|-----------|-----------|-----------|
````