### PR TITLE
fix case for backbone example from Lcovhtml to correct LcovHtml

### DIFF
--- a/backbone-example/tests/intern.js
+++ b/backbone-example/tests/intern.js
@@ -52,7 +52,7 @@ define([ 'intern' ], function (intern) {
 	};
 
 	if (intern.mode === 'runner') {
-		config.reporters = [ 'Runner', 'Lcovhtml' ];
+		config.reporters = [ 'Runner', 'LcovHtml' ];
 	}
 
 	return config;


### PR DESCRIPTION
On running backbone-example there is error 
`Error: Failed to load module intern/lib/reporters/Lcovhtml .....`
which this commit fix