### PR TITLE
Update spectron config and instructions

### DIFF
--- a/electron-example/README.md
+++ b/electron-example/README.md
@@ -32,4 +32,4 @@ On Windows, run
 
 **WebDriver tests using Spectron**
 
-    $ npm test config=intern-spectron.json
+    $ npm test config=@spectron

--- a/electron-example/tests/functional/spectron.js
+++ b/electron-example/tests/functional/spectron.js
@@ -1,5 +1,6 @@
 // A simple test to verify a visible window is opened with a title
 import { Application } from 'spectron';
+import electronPath from 'electron';
 
 const { assert } = intern.getPlugin('chai');
 const { registerSuite } = intern.getInterface('object');
@@ -9,7 +10,7 @@ let app;
 registerSuite('Application', {
 	beforeEach() {
 		app = new Application({
-			path: 'node_modules/electron/dist/Electron.app/Contents/MacOS/Electron',
+			path: electronPath,
 			args: ['build/bootstrap.js']
 		});
 		return app.start();


### PR DESCRIPTION
The readme references an old json file. The config is now set in the main intern.json.

For cross-platform compatibility, the electron path should be pulled from electron itself.